### PR TITLE
[tests] Modify kitsune tests when fetching from archive

### DIFF
--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -333,7 +333,8 @@ class TestCratesBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Crates(archive=self.archive)
+        self.backend_write_archive = Crates(archive=self.archive)
+        self.backend_read_archive = Crates(archive=self.archive)
 
     @httpretty.activate
     def test_fetch_crates_from_archive(self):
@@ -347,8 +348,8 @@ class TestCratesBackendArchive(TestCaseBackendArchive):
         """Test whether a summary is returned from archive"""
 
         setup_http_server()
-        items = [items for items in self.backend.fetch(category=CATEGORY_SUMMARY)]
-        items_archived = [items for items in self.backend.fetch_from_archive()]
+        items = [items for items in self.backend_write_archive.fetch(category=CATEGORY_SUMMARY)]
+        items_archived = [items for items in self.backend_read_archive.fetch_from_archive()]
 
         self.assertEqual(len(items), len(items_archived))
 
@@ -376,8 +377,8 @@ class TestCratesBackendArchive(TestCaseBackendArchive):
         setup_http_server()
 
         from_date = datetime.datetime(2016, 1, 1)
-        items = [items for items in self.backend.fetch(category=CATEGORY_SUMMARY, from_date=from_date)]
-        items_archived = [items for items in self.backend.fetch_from_archive()]
+        items = [items for items in self.backend_write_archive.fetch(category=CATEGORY_SUMMARY, from_date=from_date)]
+        items_archived = [items for items in self.backend_read_archive.fetch_from_archive()]
 
         self.assertEqual(len(items), len(items_archived))
 

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -242,7 +242,8 @@ class TestKitsuneBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = Kitsune(KITSUNE_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = Kitsune(KITSUNE_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = Kitsune(KITSUNE_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -186,7 +186,8 @@ class TestMozillaClubBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = MozillaClub(MozillaClub_FEED_URL, archive=self.archive)
+        self.backend_write_archive = MozillaClub(MozillaClub_FEED_URL, archive=self.archive)
+        self.backend_read_archive = MozillaClub(MozillaClub_FEED_URL, archive=self.archive)
 
     @httpretty.activate
     def test_fetch_from_archive(self):

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -294,7 +294,8 @@ class TestRemoBackendArchive(TestCaseBackendArchive):
 
     def setUp(self):
         super().setUp()
-        self.backend = ReMo(MOZILLA_REPS_SERVER_URL, archive=self.archive)
+        self.backend_write_archive = ReMo(MOZILLA_REPS_SERVER_URL, archive=self.archive)
+        self.backend_read_archive = ReMo(MOZILLA_REPS_SERVER_URL, archive=self.archive)
 
     @httpretty.activate
     def __test_fetch_from_archive(self, category='event'):


### PR DESCRIPTION
This patch adds two different backend objects (one fetches data from remote a data source and the other one from an archive) in order to ensure that backend and method params are initialized in the same way independently from which method is called (fetch or fetch_from_archive)