### PR TITLE
[remo] Add params to fetch events from older to newer

### DIFF
--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -22,6 +22,7 @@
 
 import json
 import logging
+import urllib.parse
 
 from grimoirelab.toolkit.datetime import str_to_datetime
 from grimoirelab.toolkit.uris import urijoin
@@ -54,7 +55,7 @@ class ReMo(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.7.2'
+    version = '0.7.3'
 
     CATEGORIES = [CATEGORY_ACTIVITY, CATEGORY_EVENT, CATEGORY_USER]
 
@@ -262,7 +263,8 @@ class ReMoClient(HttpClient):
 
         while more:
             params = {
-                "page": page
+                "page": page,
+                "orderby": "ASC"
             }
 
             logger.debug("ReMo client calls APIv2: %s params: %s",
@@ -277,8 +279,10 @@ class ReMoClient(HttpClient):
             if not next_uri:
                 more = False
             else:
-                # https://reps.mozilla.org/remo/api/remo/v1/events/?page=269
-                page = next_uri.split("page=")[1]
+                # https://reps.mozilla.org/remo/api/remo/v1/events/?orderby=ASC&page=269
+                parsed_uri = urllib.parse.urlparse(next_uri)
+                parsed_params = urllib.parse.parse_qs(parsed_uri.query)
+                page = parsed_params['page'][0]
 
     def fetch(self, url, payload=None):
         """Return the textual content associated to the Response object"""

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -193,10 +193,10 @@ class TestReMoBackend(unittest.TestCase):
             self.__check_activities_contents(items)
 
         # Check requests: page list, items, page list, items
-        expected = [{'page': ['1']}]
+        expected = [{'page': ['1'], 'orderby': ['ASC']}]
         for i in range(0, items_page):
             expected += [{}]
-        expected += [{'page': ['2']}]
+        expected += [{'page': ['2'], 'orderby': ['ASC']}]
         for i in range(0, items_page):
             expected += [{}]
 
@@ -389,12 +389,8 @@ class TestReMoClient(unittest.TestCase):
         req = HTTPServer.requests_http[-1]
         self.assertEqual(response, body)
         self.assertEqual(req.method, 'GET')
-        self.assertEqual(req.path, '/api/remo/v1/events/?page=1')
-        # Check request params
-        expected = {
-            'page': ['1']
-        }
-        self.assertDictEqual(req.querystring, expected)
+        self.assertRegex(req.path, '/api/remo/v1/events/')
+        self.assertDictEqual(req.querystring, {'page': ['1'], 'orderby': ['ASC']})
 
     @httpretty.activate
     def test_get_wrong_items(self):


### PR DESCRIPTION
This code enables to fetch events from the older to the newer, thus easing the collection of remo events.