### PR TITLE
Fix tests compatibility with both test execution modes

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2015-2017 Bitergia
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, 51 Franklin Street, Fifth Floor, Boston, MA 02110-1335, USA.
+#
+# Authors:
+#     Valerio Cosentino <valcos@bitergia.com>
+#     Santiago Dueñas <sduenas@bitergia.com>
+#
+
+import os
+import shutil
+import tempfile
+import unittest
+
+from perceval.archive import Archive
+
+
+class TestCaseBackendArchive(unittest.TestCase):
+    """Unit tests for Backend using the archive"""
+
+    def setUp(self):
+        self.test_path = tempfile.mkdtemp(prefix='perceval-mozilla_')
+        archive_path = os.path.join(self.test_path, 'myarchive')
+        self.archive = Archive.create(archive_path)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_path)
+
+    def _test_fetch_from_archive(self, **kwargs):
+        """Test whether the method fetch_from_archive works properly"""
+
+        items = [items for items in self.backend_write_archive.fetch(**kwargs)]
+        items_archived = [item for item in self.backend_write_archive.fetch_from_archive()]
+
+        self.assertEqual(len(items), len(items_archived))
+
+        for i in range(len(items)):
+            item = items[i]
+            archived_item = items_archived[i]
+
+            del item['timestamp']
+            del archived_item['timestamp']
+
+            self.assertEqual(item, archived_item)

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -35,7 +35,7 @@ from perceval.backends.mozilla.crates import (Crates,
                                               CATEGORY_CRATES,
                                               CATEGORY_SUMMARY)
 from perceval.utils import DEFAULT_DATETIME
-from tests.base import TestCaseBackendArchive
+from base import TestCaseBackendArchive
 
 CRATES_API_URL = "https://crates.io/api/v1/"
 

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -33,7 +33,7 @@ from perceval.backend import BackendCommandArgumentParser
 from perceval.backends.mozilla.kitsune import (Kitsune,
                                                KitsuneCommand,
                                                KitsuneClient)
-from tests.base import TestCaseBackendArchive
+from base import TestCaseBackendArchive
 
 
 KITSUNE_SERVER_URL = 'http://example.com'

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -31,7 +31,7 @@ from perceval.backends.mozilla.mozillaclub import (MozillaClub,
                                                    MozillaClubCommand,
                                                    MozillaClubClient,
                                                    MozillaClubParser)
-from tests.base import TestCaseBackendArchive
+from base import TestCaseBackendArchive
 
 
 MozillaClub_FEED_URL = 'http://example.com/feed'

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -32,7 +32,7 @@ from perceval.backends.mozilla.remo import (ReMo,
                                             ReMoCommand,
                                             ReMoClient,
                                             MOZILLA_REPS_URL)
-from tests.base import TestCaseBackendArchive
+from base import TestCaseBackendArchive
 
 MOZILLA_REPS_SERVER_URL = 'http://example.com'
 MOZILLA_REPS_API = MOZILLA_REPS_SERVER_URL + '/api/remo/v1'


### PR DESCRIPTION
To avoid import problems, it was necessary to add `base.py` script, an empty `__init__.py` file into tests directory and change how the package is imported in each test.

About `base.py` script, is the same as the one in [Perceval](https://github.com/chaoss/grimoirelab-perceval/blob/master/tests/base.py) repository, but changing the `test_path` name (See in-line comment below).