### PR TITLE
[travis] Change how perceval-mozilla is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_install:
   - pip install coveralls
 
 install:
-  - ./setup.py install
+  - pip install .
 
 script:
   - flake8 .


### PR DESCRIPTION
This code modifies how perceval-mozilla is installed, thus now the installation is achieved via `pip install .`