### PR TITLE
Update metadata due to classified fields filtering feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The backends currently managed by this package support the next repositories:
 * Python >= 3.4
 * python3-requests >= 2.7
 * grimoirelab-toolkit >= 0.1
-* perceval >= 0.11.0
+* perceval >= 0.12.8
 
 ## Installation
 

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -57,7 +57,7 @@ class Kitsune(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.6.2'
+    version = '0.6.3'
 
     CATEGORIES = [CATEGORY_QUESTION]
 
@@ -122,7 +122,7 @@ class Kitsune(Backend):
                 # Continue with the next page if it is a 500 error
                 if e.response.status_code == 500:
                     logger.exception(e)
-                    logger.error("Problem getting Kitsune questions. " +
+                    logger.error("Problem getting Kitsune questions. "
                                  "Loosing %i questions. Going to the next page.",
                                  KitsuneClient.ITEMS_PER_PAGE)
                     equestions += KitsuneClient.ITEMS_PER_PAGE
@@ -161,15 +161,16 @@ class Kitsune(Backend):
         logger.info("Total number of questions: %i (%i total)", nquestions, tquestions)
         logger.info("Questions with errors dropped: %i", equestions)
 
-    def metadata(self, item):
+    def metadata(self, item, filter_classified=False):
         """Kitsune metadata.
 
         This method takes items overrides `metadata` method to add extra
         information related to Kitsune (offset of the question).
 
         :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
         """
-        item = super().metadata(item)
+        item = super().metadata(item, filter_classified=filter_classified)
         item['offset'] = item['data'].pop('offset')
 
         return item

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -55,7 +55,7 @@ class ReMo(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.7.3'
+    version = '0.7.4'
 
     CATEGORIES = [CATEGORY_ACTIVITY, CATEGORY_EVENT, CATEGORY_USER]
 
@@ -134,15 +134,16 @@ class ReMo(Backend):
 
         logger.info("Total number of events: %i (%i total, %i offset)", nitems, titems, offset)
 
-    def metadata(self, item):
+    def metadata(self, item, filter_classified=False):
         """ReMo metadata.
 
         This method takes items overrides `metadata` method to add extra
-        information related to Kitsune (offset of the item).
+        information related to Remo (offset of the item).
 
         :param item: an item fetched by a backend
+        :param filter_classified: sets if classified fields were filtered
         """
-        item = super().metadata(item)
+        item = super().metadata(item, filter_classified=filter_classified)
         item['offset'] = item['data'].pop('offset')
 
         return item

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ try:
     import pypandoc
     long_description = pypandoc.convert(readme_md, 'rst')
 except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. " +
+    print("Warning: pypandoc module not found, or pandoc not installed. "
           "Using md instead of rst")
     with codecs.open(readme_md, encoding='utf-8') as f:
         long_description = f.read()
@@ -102,7 +102,7 @@ setup(name="perceval-mozilla",
       install_requires=[
           'requests>=2.7.0',
           'grimoirelab-toolkit>=0.1.0',
-          'perceval>=0.11.0'
+          'perceval>=0.12.8'
       ],
       cmdclass=cmdclass,
       zip_safe=False)


### PR DESCRIPTION
Since Perceval 0.2.18, classified fields filtering was added. This requires to add the parameter `filter_classified` to `metadata()` method. This PR updates Mozilla backends to support this feature. 