### PR TITLE
[backends] Include available category options in the helptext

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -339,11 +339,12 @@ class CratesCommand(BackendCommand):
 
     BACKEND = Crates
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the Crates argument parser."""
 
-        parser = BackendCommandArgumentParser(from_date=True,
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              from_date=True,
                                               archive=True,
                                               token_auth=True)
 

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -306,11 +306,12 @@ class KitsuneCommand(BackendCommand):
 
     BACKEND = Kitsune
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the Kitsune argument parser."""
 
-        parser = BackendCommandArgumentParser(offset=True,
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              offset=True,
                                               archive=True)
 
         # Required arguments

--- a/perceval/backends/mozilla/mozillaclub.py
+++ b/perceval/backends/mozilla/mozillaclub.py
@@ -348,11 +348,12 @@ class MozillaClubCommand(BackendCommand):
 
     BACKEND = MozillaClub
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the MozillaClub argument parser."""
 
-        parser = BackendCommandArgumentParser(archive=True)
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              archive=True)
 
         # Required arguments
         parser.parser.add_argument('url', nargs='?',

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -298,11 +298,12 @@ class ReMoCommand(BackendCommand):
 
     BACKEND = ReMo
 
-    @staticmethod
-    def setup_cmd_parser():
+    @classmethod
+    def setup_cmd_parser(cls):
         """Returns the ReMo argument parser."""
 
-        parser = BackendCommandArgumentParser(offset=True,
+        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+                                              offset=True,
                                               archive=True)
         # Required arguments
         parser.parser.add_argument('url', nargs='?',

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -456,6 +456,7 @@ class TestCratesCommand(unittest.TestCase):
 
         parser = CratesCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, Crates.CATEGORIES)
 
         args = ['--tag', 'test',
                 '--from-date', '1970-01-01',

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -301,6 +301,7 @@ class TestKitsuneCommand(unittest.TestCase):
 
         parser = KitsuneCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, Kitsune.CATEGORIES)
 
         args = [KITSUNE_SERVER_URL,
                 '--tag', 'test',

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -228,6 +228,7 @@ class TestMozillaClubCommand(unittest.TestCase):
 
         parser = MozillaClubCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, MozillaClub.CATEGORIES)
 
         args = [MozillaClub_FEED_URL,
                 '--tag', 'test',

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -348,6 +348,7 @@ class TestReMoCommand(unittest.TestCase):
 
         parser = ReMoCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
+        self.assertEqual(parser._categories, ReMo.CATEGORIES)
 
         args = [MOZILLA_REPS_SERVER_URL,
                 '--category', 'user',


### PR DESCRIPTION
Minor update in the backends to include available category options to the helptext and align it to the parent Backend.
@valeriocos @sduenas please see.