### PR TITLE
[setup] Fix format type for long description of package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,18 +34,9 @@ from setuptools.command.test import test as TestClass
 here = os.path.abspath(os.path.dirname(__file__))
 readme_md = os.path.join(here, 'README.md')
 
-# Pypi wants the description to be in reStrcuturedText, but
-# we have it in Markdown. So, let's convert formats.
-# Set up thinkgs so that if pypandoc is not installed, it
-# just issues a warning.
-try:
-    import pypandoc
-    long_description = pypandoc.convert(readme_md, 'rst')
-except (IOError, ImportError):
-    print("Warning: pypandoc module not found, or pandoc not installed. "
-          "Using md instead of rst")
-    with codecs.open(readme_md, encoding='utf-8') as f:
-        long_description = f.read()
+# Get the package description from the README.md file
+with codecs.open(readme_md, encoding='utf-8') as f:
+    long_description = f.read()
 
 
 version = '0.2.6'
@@ -70,6 +61,7 @@ cmdclass = {'test': TestCommand}
 setup(name="perceval-mozilla",
       description="Bundle of Perceval backends for Mozilla ecosystem",
       long_description=long_description,
+      long_description_content_type='text/markdown',
       url="https://github.com/grimoirelab/perceval-mozilla",
       version=version,
       author="Bitergia",


### PR DESCRIPTION
Pypi requires that the format of the long description for a package is detailed in the variable `long_description_content_type`, in setup.py. Since it now supports Markdown, the conversion to
reST is not needed anymore.