### PR TITLE
[backend] Add search fields in metadata items

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -55,7 +55,7 @@ class Crates(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.3.2'
+    version = '0.4.0'
 
     CATEGORIES = [CATEGORY_CRATES, CATEGORY_SUMMARY]
 

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -56,7 +56,7 @@ class Kitsune(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.6.3'
+    version = '0.7.0'
 
     CATEGORIES = [CATEGORY_QUESTION]
 

--- a/perceval/backends/mozilla/mozillaclub.py
+++ b/perceval/backends/mozilla/mozillaclub.py
@@ -70,9 +70,12 @@ class MozillaClub(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.3.3'
+    version = '0.4.0'
 
     CATEGORIES = [CATEGORY_EVENT]
+    EXTRA_SEARCH_FIELDS = {
+        'club_name': ['Club Name']
+    }
 
     def __init__(self, url=MOZILLA_CLUB_URL, tag=None, archive=None):
         origin = url

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -54,7 +54,7 @@ class ReMo(Backend):
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
     """
-    version = '0.7.4'
+    version = '0.8.0'
 
     CATEGORIES = [CATEGORY_ACTIVITY, CATEGORY_EVENT, CATEGORY_USER]
 

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -258,6 +258,18 @@ class TestCratesBackend(unittest.TestCase):
         self.assertEqual(len(item['data']['versions_data']['versions']), 7)
 
     @httpretty.activate
+    def test_crates_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        setup_http_server()
+
+        backend = Crates()
+        items = [items for items in backend.fetch(from_date=None)]
+
+        for item in items:
+            self.assertEqual(backend.metadata_id(item['data']), item['search_fields']['item_id'])
+
+    @httpretty.activate
     def test_fetch_summary(self):
         """Test whether a summary is returned"""
 
@@ -270,6 +282,18 @@ class TestCratesBackend(unittest.TestCase):
         self.assertEqual(items[0]['category'], CATEGORY_SUMMARY)
         self.assertEqual(items[0]['data']['num_crates'], 10000)
         self.assertEqual(items[0]['data']['num_downloads'], 2000000000)
+
+    @httpretty.activate
+    def test_summary_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        setup_http_server()
+
+        backend = Crates()
+        items = [items for items in backend.fetch(category=CATEGORY_SUMMARY)]
+
+        for item in items:
+            self.assertEqual(backend.metadata_id(item['data']), item['search_fields']['item_id'])
 
     @httpretty.activate
     def test_fetch_from_date(self):

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -235,6 +235,20 @@ class TestKitsuneBackend(unittest.TestCase):
         # After the failing page there are a page with 2 questions
         self.assertEqual(len(questions), 2)
 
+    @httpretty.activate
+    def test_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        HTTPServer.routes()
+
+        # Test fetch questions with their reviews
+        kitsune = Kitsune(KITSUNE_SERVER_URL)
+
+        questions = [question for question in kitsune.fetch(offset=None)]
+
+        for question in questions:
+            self.assertEqual(kitsune.metadata_id(question['data']), question['search_fields']['item_id'])
+
 
 class TestKitsuneBackendArchive(TestCaseBackendArchive):
     """Kitsune backend tests using an archive"""

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -179,6 +179,30 @@ class TestMozillaClubBackend(unittest.TestCase):
 
         self.assertEqual(len(events), 0)
 
+    @httpretty.activate
+    def test_search_fields(self):
+        """Test whether the search_fields is properly set"""
+
+        configure_http_server()
+
+        mozillaclub = MozillaClub(MozillaClub_FEED_URL)
+        events = [event for event in mozillaclub.fetch()]
+
+        event = events[0]
+        self.assertEqual(mozillaclub.metadata_id(event['data']), event['search_fields']['item_id'])
+        self.assertEqual(event['data']['Club Name'], 'Rio Mozilla Club')
+        self.assertEqual(event['data']['Club Name'], event['search_fields']['club_name'])
+
+        event = events[1]
+        self.assertEqual(mozillaclub.metadata_id(event['data']), event['search_fields']['item_id'])
+        self.assertEqual(event['data']['Club Name'], 'Firefox club uog-skt')
+        self.assertEqual(event['data']['Club Name'], event['search_fields']['club_name'])
+
+        event = events[2]
+        self.assertEqual(mozillaclub.metadata_id(event['data']), event['search_fields']['item_id'])
+        self.assertEqual(event['data']['Club Name'], 'Mozilla HETEC Club')
+        self.assertEqual(event['data']['Club Name'], event['search_fields']['club_name'])
+
 
 class TestMozillaClubBackendArchive(TestCaseBackendArchive):
     """MozillaClub backend tests using an archive"""

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -204,6 +204,23 @@ class TestReMoBackend(unittest.TestCase):
         for i in range(len(expected)):
             self.assertDictEqual(HTTPServer.requests_http[i].querystring, expected[i])
 
+    @httpretty.activate
+    def __test_search_terms(self, category='event'):
+        """Test whether the search_fields is properly set"""
+
+        items_page = ReMoClient.ITEMS_PER_PAGE
+        pages = 2  # two pages of testing data
+
+        HTTPServer.routes()
+
+        # Test fetch events with their reviews
+        remo = ReMo(MOZILLA_REPS_SERVER_URL)
+
+        items = [page for page in remo.fetch(offset=None, category=category)]
+
+        for item in items:
+            self.assertEqual(remo.metadata_id(item['data']), item['search_fields']['item_id'])
+
     def test_fetch_events(self):
         self.__test_fetch(category='event')
 
@@ -212,6 +229,15 @@ class TestReMoBackend(unittest.TestCase):
 
     def test_fetch_users(self):
         self.__test_fetch(category='user')
+
+    def test_search_terms_events(self):
+        self.__test_search_terms(category='event')
+
+    def test_search_terms_activities(self):
+        self.__test_search_terms(category='activity')
+
+    def test_search_terms_users(self):
+        self.__test_search_terms(category='user')
 
     @httpretty.activate
     def tests_wrong_metadata_updated_on(self):


### PR DESCRIPTION
This code enhances the metadata information with a set of search fields, which simplify query operations and avoid the manual inspections of the Perceval items.

These fields are added to the item metadata information in the search_fields attribute. By default, search_fields contains the id of the item ('item_id': item_id_value), obtained via the metadata_id method). However each backend can set extra search fields using the dict EXTRA_SEARCH_FIELDS. An example of EXTRA_SEARCH_FIELDS is provided below:

   {
      'project_id': ['fields', 'project', 'id'],
      'project_key': ['fields', 'project', 'key'],
      'project_name': ['fields', 'project', 'name']
   }
Each key in the dict is a search field to be included in the item metadata information, while the corresponding value is a list that stores the "path" of the search field value within the item.

Related to https://github.com/chaoss/grimoirelab-perceval/pull/574