### PR TITLE
[backend] Change signature BackendCommandArgumentParser

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -342,7 +342,7 @@ class CratesCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Crates argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True,
                                               token_auth=True)

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -309,7 +309,7 @@ class KitsuneCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the Kitsune argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
                                               archive=True)
 

--- a/perceval/backends/mozilla/mozillaclub.py
+++ b/perceval/backends/mozilla/mozillaclub.py
@@ -354,7 +354,7 @@ class MozillaClubCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the MozillaClub argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               archive=True)
 
         # Required arguments

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -301,7 +301,7 @@ class ReMoCommand(BackendCommand):
     def setup_cmd_parser(cls):
         """Returns the ReMo argument parser."""
 
-        parser = BackendCommandArgumentParser(cls.BACKEND.CATEGORIES,
+        parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
                                               archive=True)
         # Required arguments

--- a/tests/test_crates.py
+++ b/tests/test_crates.py
@@ -479,7 +479,7 @@ class TestCratesCommand(unittest.TestCase):
 
         parser = CratesCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Crates.CATEGORIES)
+        self.assertEqual(parser._backend, Crates)
 
         args = ['--tag', 'test',
                 '--from-date', '1970-01-01',

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -314,7 +314,7 @@ class TestKitsuneCommand(unittest.TestCase):
 
         parser = KitsuneCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, Kitsune.CATEGORIES)
+        self.assertEqual(parser._backend, Kitsune)
 
         args = [KITSUNE_SERVER_URL,
                 '--tag', 'test',

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -251,7 +251,7 @@ class TestMozillaClubCommand(unittest.TestCase):
 
         parser = MozillaClubCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, MozillaClub.CATEGORIES)
+        self.assertEqual(parser._backend, MozillaClub)
 
         args = [MozillaClub_FEED_URL,
                 '--tag', 'test',

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -373,7 +373,7 @@ class TestReMoCommand(unittest.TestCase):
 
         parser = ReMoCommand.setup_cmd_parser()
         self.assertIsInstance(parser, BackendCommandArgumentParser)
-        self.assertEqual(parser._categories, ReMo.CATEGORIES)
+        self.assertEqual(parser._backend, ReMo)
 
         args = [MOZILLA_REPS_SERVER_URL,
                 '--category', 'user',


### PR DESCRIPTION
This code changes the signature of the class `BackendCommandArgumentParser`,
which now accepts as first parameter the backend object instead
its categories. This change is needed to simplify accessing other backend
attributes, beyond the categories.

All backends and corresponding tests have been updated.

Signed-off-by: Valerio Cosentino <valcos@bitergia.com>