### PR TITLE
Support for SSL verification

### DIFF
--- a/perceval/backends/mozilla/crates.py
+++ b/perceval/backends/mozilla/crates.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Valerio Cosentino <valcos@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -54,15 +55,16 @@ class Crates(Backend):
     :param sleep_time: sleep time in case of connection lost
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.4.0'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_CRATES, CATEGORY_SUMMARY]
 
-    def __init__(self, sleep_time=SLEEP_TIME, tag=None, archive=None):
+    def __init__(self, sleep_time=SLEEP_TIME, tag=None, archive=None, ssl_verify=True):
         origin = CRATES_URL
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.sleep_time = sleep_time
 
         self.client = None
@@ -164,7 +166,7 @@ class Crates(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return CratesClient(self.sleep_time, self.archive, from_archive)
+        return CratesClient(self.sleep_time, self.archive, from_archive, self.ssl_verify)
 
     def __fetch_summary(self):
         """Fetch summary"""
@@ -254,14 +256,15 @@ class CratesClient(HttpClient):
         of connection problems
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
     """
 
     MAX_RETRIES = 5
 
-    def __init__(self, sleep_time=SLEEP_TIME, archive=None, from_archive=False):
+    def __init__(self, sleep_time=SLEEP_TIME, archive=None, from_archive=False, ssl_verify=True):
         super().__init__(CRATES_API_URL, sleep_time=sleep_time, max_retries=CratesClient.MAX_RETRIES,
                          extra_headers={'Content-type': 'application/json'},
-                         archive=archive, from_archive=from_archive)
+                         archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def summary(self):
         """Get Crates.io summary"""
@@ -345,7 +348,8 @@ class CratesCommand(BackendCommand):
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               from_date=True,
                                               archive=True,
-                                              token_auth=True)
+                                              token_auth=True,
+                                              ssl_verify=True)
 
         # Optional arguments
         group = parser.parser.add_argument_group('Crates.io arguments')

--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -55,17 +56,18 @@ class Kitsune(Backend):
     :param url: Kitsune URL
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.7.0'
+    version = '0.8.0'
 
     CATEGORIES = [CATEGORY_QUESTION]
 
-    def __init__(self, url=None, tag=None, archive=None):
+    def __init__(self, url=None, tag=None, archive=None, ssl_verify=True):
         if not url:
             url = KITSUNE_URL
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
 
         self.client = None
@@ -222,7 +224,7 @@ class Kitsune(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return KitsuneClient(self.url, self.archive, from_archive)
+        return KitsuneClient(self.url, self.archive, from_archive, self.ssl_verify)
 
 
 class KitsuneClient(HttpClient):
@@ -234,14 +236,15 @@ class KitsuneClient(HttpClient):
     :param url: URL of Kitsune (sample https://support.mozilla.org)
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
     FIRST_PAGE = 1  # Initial page in Kitsune
     ITEMS_PER_PAGE = 20  # Items per page in Kitsune API
 
-    def __init__(self, url, archive=None, from_archive=False):
-        super().__init__(urijoin(url, '/api/2/'), archive=archive, from_archive=from_archive)
+    def __init__(self, url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(urijoin(url, '/api/2/'), archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def get_questions(self, offset=None):
         """Retrieve questions from older to newer updated starting offset"""
@@ -311,7 +314,8 @@ class KitsuneCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url', nargs='?',

--- a/perceval/backends/mozilla/mozillaclub.py
+++ b/perceval/backends/mozilla/mozillaclub.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -69,18 +70,19 @@ class MozillaClub(Backend):
     :param url: Mozilla Club Events url
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.4.0'
+    version = '0.5.0'
 
     CATEGORIES = [CATEGORY_EVENT]
     EXTRA_SEARCH_FIELDS = {
         'club_name': ['Club Name']
     }
 
-    def __init__(self, url=MOZILLA_CLUB_URL, tag=None, archive=None):
+    def __init__(self, url=MOZILLA_CLUB_URL, tag=None, archive=None, ssl_verify=True):
         origin = url
         self.url = url
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
 
         self.client = None
 
@@ -170,7 +172,7 @@ class MozillaClub(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return MozillaClubClient(self.url, self.archive, from_archive)
+        return MozillaClubClient(self.url, self.archive, from_archive, self.ssl_verify)
 
 
 class MozillaClubClient(HttpClient):
@@ -182,11 +184,12 @@ class MozillaClubClient(HttpClient):
     :param url: URL of MozillaClub
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
-    def __init__(self, url, archive=None, from_archive=False):
-        super().__init__(url, archive=archive, from_archive=from_archive)
+    def __init__(self, url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
 
     def get_cells(self):
         """Retrieve all cells from the spreadsheet."""
@@ -355,7 +358,8 @@ class MozillaClubCommand(BackendCommand):
         """Returns the MozillaClub argument parser."""
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
 
         # Required arguments
         parser.parser.add_argument('url', nargs='?',

--- a/perceval/backends/mozilla/remo.py
+++ b/perceval/backends/mozilla/remo.py
@@ -17,6 +17,7 @@
 #
 # Authors:
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import json
@@ -53,17 +54,18 @@ class ReMo(Backend):
     :param url: ReMo URL
     :param tag: label used to mark the data
     :param archive: archive to store/retrieve items
+    :param ssl_verify: enable/disable SSL verification
     """
-    version = '0.8.0'
+    version = '0.9.0'
 
     CATEGORIES = [CATEGORY_ACTIVITY, CATEGORY_EVENT, CATEGORY_USER]
 
-    def __init__(self, url=None, tag=None, archive=None):
+    def __init__(self, url=None, tag=None, archive=None, ssl_verify=True):
         if not url:
             url = MOZILLA_REPS_URL
         origin = url
 
-        super().__init__(origin, tag=tag, archive=archive)
+        super().__init__(origin, tag=tag, archive=archive, ssl_verify=ssl_verify)
         self.url = url
         self.client = None
 
@@ -215,7 +217,7 @@ class ReMo(Backend):
     def _init_client(self, from_archive=False):
         """Init client"""
 
-        return ReMoClient(self.url, self.archive, from_archive)
+        return ReMoClient(self.url, self.archive, from_archive, self.ssl_verify)
 
 
 class ReMoClient(HttpClient):
@@ -227,6 +229,7 @@ class ReMoClient(HttpClient):
     :param url: URL of ReMo (sample https://reps.mozilla.org)
     :param archive: an archive to store/read fetched data
     :param from_archive: it tells whether to write/read the archive
+    :param ssl_verify: enable/disable SSL verification
 
     :raises HTTPError: when an error occurs doing the request
     """
@@ -235,8 +238,8 @@ class ReMoClient(HttpClient):
     ITEMS_PER_PAGE = 20  # Items per page in ReMo API
     API_PATH = '/api/remo/v1'
 
-    def __init__(self, url, archive=None, from_archive=False):
-        super().__init__(url, archive=archive, from_archive=from_archive)
+    def __init__(self, url, archive=None, from_archive=False, ssl_verify=True):
+        super().__init__(url, archive=archive, from_archive=from_archive, ssl_verify=ssl_verify)
         self.api_activities_url = urijoin(self.base_url, ReMoClient.API_PATH + '/activities/')
         self.api_activities_url += '/'  # API needs a final /
         self.api_events_url = urijoin(self.base_url, ReMoClient.API_PATH + '/events/')
@@ -303,7 +306,8 @@ class ReMoCommand(BackendCommand):
 
         parser = BackendCommandArgumentParser(cls.BACKEND,
                                               offset=True,
-                                              archive=True)
+                                              archive=True,
+                                              ssl_verify=True)
         # Required arguments
         parser.parser.add_argument('url', nargs='?',
                                    default="https://reps.mozilla.org",

--- a/tests/test_mozillaclub.py
+++ b/tests/test_mozillaclub.py
@@ -19,6 +19,7 @@
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import unittest
@@ -85,18 +86,21 @@ class TestMozillaClubBackend(unittest.TestCase):
         self.assertEqual(mozillaclub.origin, MozillaClub_FEED_URL)
         self.assertEqual(mozillaclub.tag, 'test')
         self.assertIsNone(mozillaclub.client)
+        self.assertTrue(mozillaclub.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
-        mozillaclub = MozillaClub(MozillaClub_FEED_URL)
+        mozillaclub = MozillaClub(MozillaClub_FEED_URL, ssl_verify=False)
         self.assertEqual(mozillaclub.url, MozillaClub_FEED_URL)
         self.assertEqual(mozillaclub.origin, MozillaClub_FEED_URL)
         self.assertEqual(mozillaclub.tag, MozillaClub_FEED_URL)
+        self.assertFalse(mozillaclub.ssl_verify)
 
         mozillaclub = MozillaClub(MozillaClub_FEED_URL, tag='')
         self.assertEqual(mozillaclub.url, MozillaClub_FEED_URL)
         self.assertEqual(mozillaclub.origin, MozillaClub_FEED_URL)
         self.assertEqual(mozillaclub.tag, MozillaClub_FEED_URL)
+        self.assertTrue(mozillaclub.ssl_verify)
 
     def test_has_archiving(self):
         """Test if it returns True when has_archiving is called"""
@@ -261,6 +265,13 @@ class TestMozillaClubCommand(unittest.TestCase):
         self.assertEqual(parsed_args.url, MozillaClub_FEED_URL)
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.no_archive, True)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = [MozillaClub_FEED_URL, '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, MozillaClub_FEED_URL)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestMozillaClubClient(unittest.TestCase):
@@ -271,10 +282,23 @@ class TestMozillaClubClient(unittest.TestCase):
     into account that the body returned on each request might not
     match with the parameters from the request.
     """
-    @httpretty.activate
+
     def test_init(self):
         """Test initialization"""
-        client = MozillaClubClient(MozillaClub_FEED_URL)
+
+        mozillaclub = MozillaClubClient(MozillaClub_FEED_URL)
+
+        self.assertEqual(mozillaclub.base_url, MozillaClub_FEED_URL)
+        self.assertIsNone(mozillaclub.archive)
+        self.assertFalse(mozillaclub.from_archive)
+        self.assertTrue(mozillaclub.ssl_verify)
+
+        mozillaclub = MozillaClubClient(MozillaClub_FEED_URL, ssl_verify=False)
+
+        self.assertEqual(mozillaclub.base_url, MozillaClub_FEED_URL)
+        self.assertIsNone(mozillaclub.archive)
+        self.assertFalse(mozillaclub.from_archive)
+        self.assertFalse(mozillaclub.ssl_verify)
 
     @httpretty.activate
     def test_get_events(self):

--- a/tests/test_remo.py
+++ b/tests/test_remo.py
@@ -19,6 +19,7 @@
 # Authors:
 #     Santiago Dueñas <sduenas@bitergia.com>
 #     Alvaro del Castillo <acs@bitergia.com>
+#     Quan Zhou <quan@bitergia.com>
 #
 
 import re
@@ -105,18 +106,21 @@ class TestReMoBackend(unittest.TestCase):
         self.assertEqual(remo.origin, MOZILLA_REPS_SERVER_URL)
         self.assertEqual(remo.tag, 'test')
         self.assertIsNone(remo.client)
+        self.assertTrue(remo.ssl_verify)
 
         # When tag is empty or None it will be set to
         # the value in url
-        remo = ReMo(MOZILLA_REPS_SERVER_URL)
+        remo = ReMo(MOZILLA_REPS_SERVER_URL, ssl_verify=False)
         self.assertEqual(remo.url, MOZILLA_REPS_SERVER_URL)
         self.assertEqual(remo.origin, MOZILLA_REPS_SERVER_URL)
         self.assertEqual(remo.tag, MOZILLA_REPS_SERVER_URL)
+        self.assertFalse(remo.ssl_verify)
 
         remo = ReMo(MOZILLA_REPS_SERVER_URL, tag='')
         self.assertEqual(remo.url, MOZILLA_REPS_SERVER_URL)
         self.assertEqual(remo.origin, MOZILLA_REPS_SERVER_URL)
         self.assertEqual(remo.tag, MOZILLA_REPS_SERVER_URL)
+        self.assertTrue(remo.ssl_verify)
 
         # If no url is provided, MOZILLA_REPS_URL is used
         remo = ReMo()
@@ -387,6 +391,13 @@ class TestReMoCommand(unittest.TestCase):
         self.assertEqual(parsed_args.tag, 'test')
         self.assertEqual(parsed_args.no_archive, True)
         self.assertEqual(parsed_args.offset, 88)
+        self.assertTrue(parsed_args.ssl_verify)
+
+        args = [MOZILLA_REPS_SERVER_URL, '--no-ssl-verify']
+
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.url, MOZILLA_REPS_SERVER_URL)
+        self.assertFalse(parsed_args.ssl_verify)
 
 
 class TestReMoClient(unittest.TestCase):
@@ -397,10 +408,23 @@ class TestReMoClient(unittest.TestCase):
     into account that the body returned on each request might not
     match with the parameters from the request.
     """
-    @httpretty.activate
+
     def test_init(self):
         """Test initialization"""
-        client = ReMoClient(MOZILLA_REPS_SERVER_URL)
+
+        remo = ReMoClient(MOZILLA_REPS_SERVER_URL)
+
+        self.assertEqual(remo.base_url, MOZILLA_REPS_SERVER_URL)
+        self.assertIsNone(remo.archive)
+        self.assertFalse(remo.from_archive)
+        self.assertTrue(remo.ssl_verify)
+
+        remo = ReMoClient(MOZILLA_REPS_SERVER_URL, ssl_verify=False)
+
+        self.assertEqual(remo.base_url, MOZILLA_REPS_SERVER_URL)
+        self.assertIsNone(remo.archive)
+        self.assertFalse(remo.from_archive)
+        self.assertFalse(remo.ssl_verify)
 
     @httpretty.activate
     def test_get_items(self):


### PR DESCRIPTION
This code enhances the backend with the support
to disable SSL verification.

Tests have been added accordingly.

For:
- crates
- kitsune
- mozillaclub
- remo

Signed-off-by: Quan Zhou quan@bitergia.com