### PR TITLE
[kitsune] Fix resuming feature

### DIFF
--- a/releases/unreleased/kitsune-resuming-feature-fixed.yml
+++ b/releases/unreleased/kitsune-resuming-feature-fixed.yml
@@ -1,0 +1,11 @@
+---
+title: Kitsune resuming feature fixed
+category: fixed
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: 79
+notes: >
+  Kitsune backend resuming feature was broken.
+  It didn't retrieve the updated questions right
+  using the parameter 'offset'.
+  Changing the backend to use 'from-date' parameter
+  instead has fixed the problem.


### PR DESCRIPTION
The backend used the parameter 'offset' to retrieve new data. When an offset is given, the backend considers it as the number of questions that will discard before getting new data, because in the last run it retrieved up to that number of questions.

For example, if on a first retrieval there were 10 questions, the offset will be 10. When the backend runs again using 10 as offset, it will discard the 10 first questions that were updated during that time and, retrieve questions from there.

This approach is totally wrong because there could have been questions updated but discarded. Using the previous example, if after the first retrieval, 10 new questions were created and 10 more were updated, the backend will only fetch 10 and not 20, which were the number of updated questions.

To fix this issue we use the filter 'from_date', that will retrieve those questions updated after a given date.

Notice that the item's field 'updated' on each question is not updated when a new answer is added/updated. For that reason, we need to look for the maximum date in the question and its answers to set the correct metadata value 'updated_on'.