### PR TITLE
[kitsune] Add blacklist feature to Kitsune backend

### DIFF
--- a/releases/unreleased/blacklist-feature-to-kitsune-backend.yml
+++ b/releases/unreleased/blacklist-feature-to-kitsune-backend.yml
@@ -1,0 +1,8 @@
+---
+title: Blacklist feature to Kitsune backend
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Add blacklist feature to Kitsune backend. This allows to skip
+  questions using `--blacklist-ids 100 200 300`.


### PR DESCRIPTION
This PR adds blacklist feature to Kitsune backend to skip questions. They can be blacklisted using `--blacklist-ids 100 200 300 ...`

Fails:
```
perceval kitsune --from-date 2025-04-16T15:24:38Z
```
Works:
```
perceval kitsune --from-date 2025-04-16T15:24:38Z --blacklist-ids 1506356
```

Tests have been changed accordingly.

Backend version is now 2.1.0