### PR TITLE
[Kitsune] Handle 500 errors on question answers

### DIFF
--- a/releases/unreleased/handle-kitsune-server-errors.yml
+++ b/releases/unreleased/handle-kitsune-server-errors.yml
@@ -1,0 +1,9 @@
+---
+title: Handle Kitsune server errors
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  This change adds retry logic for HTTP 500 errors when
+  fetching answers. Ignores the answers after several
+  retries.


### PR DESCRIPTION
This change adds retry logic for HTTP 500 errors when fetching answers. If the request fails, it will retry up to a maximum number of attempts, with exponential backoff.

A sleep is included between queries to avoid hitting rate limits that slow down the process.