### PR TITLE
[kitsune] Throttle API requests to respect the rate limit

### DIFF
--- a/perceval/backends/mozilla/kitsune.py
+++ b/perceval/backends/mozilla/kitsune.py
@@ -48,6 +48,10 @@ CATEGORY_QUESTION = "question"
 DEFAULT_SLEEP_TIME = 180
 MAX_RETRIES = 5
 
+# The Kitsune/SUMO API rate-limits clients that issue requests faster than
+# roughly one per second, so requests are spaced by at least this many seconds.
+MIN_REQUEST_INTERVAL = 1.0
+
 
 class Kitsune(Backend):
     """Kitsune backend for Perceval.
@@ -68,16 +72,19 @@ class Kitsune(Backend):
         of connection problems
     :param max_retries: number of max retries to a data source
         before raising a RetryError exception
+    :param min_request_interval: minimum number of seconds between consecutive
+        API requests (the Kitsune/SUMO API rate-limits faster clients)
     :param blacklist_ids: ids of items that must not be retrieved
     """
-    version = '2.1.0'
+    version = '2.2.0'
 
     CATEGORIES = [CATEGORY_QUESTION]
     ORIGIN_UNIQUE_FIELD = OriginUniqueField(name='id', type=int)
 
     def __init__(self, url=None, tag=None, archive=None, ssl_verify=True,
                  sleep_for_rate=False, sleep_time=DEFAULT_SLEEP_TIME,
-                 max_retries=MAX_RETRIES, blacklist_ids=None):
+                 max_retries=MAX_RETRIES, min_request_interval=MIN_REQUEST_INTERVAL,
+                 blacklist_ids=None):
         if not url:
             url = KITSUNE_URL
         origin = url
@@ -88,6 +95,7 @@ class Kitsune(Backend):
         self.sleep_for_rate = sleep_for_rate
         self.sleep_time = sleep_time
         self.max_retries = max_retries
+        self.min_request_interval = min_request_interval
 
         self.client = None
 
@@ -204,7 +212,8 @@ class Kitsune(Backend):
         """Init client"""
 
         return KitsuneClient(self.url, self.ssl_verify, self.sleep_for_rate,
-                             self.sleep_time, self.max_retries)
+                             self.sleep_time, self.max_retries,
+                             self.min_request_interval)
 
 
 class KitsuneClient(HttpClient):
@@ -218,6 +227,8 @@ class KitsuneClient(HttpClient):
     :param sleep_for_rate: sleep until rate limit is reset
     :param sleep_time: seconds to sleep for rate limit
     :param max_retries: number of max retries for RateLimit
+    :param min_request_interval: minimum number of seconds between consecutive
+        API requests (the Kitsune/SUMO API rate-limits faster clients)
 
     :raises HTTPError: when an error occurs doing the request
     """
@@ -225,12 +236,15 @@ class KitsuneClient(HttpClient):
     ITEMS_PER_PAGE = 20  # Items per page in Kitsune API
 
     def __init__(self, url, ssl_verify=True, sleep_for_rate=False,
-                 sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES):
+                 sleep_time=DEFAULT_SLEEP_TIME, max_retries=MAX_RETRIES,
+                 min_request_interval=MIN_REQUEST_INTERVAL):
         super().__init__(urijoin(url, '/api/2/'), ssl_verify=ssl_verify)
 
         self.sleep_for_rate = sleep_for_rate
         self.sleep_time = sleep_time
         self.max_retries = max_retries
+        self.min_request_interval = min_request_interval
+        self._last_request = None
 
     def get_questions(self, from_date):
         """Retrieve questions from older to newer updated starting offset"""
@@ -319,6 +333,19 @@ class KitsuneClient(HttpClient):
         else:
             raise RateLimitError(cause=cause, seconds_to_reset=self.sleep_time)
 
+    def _wait_for_min_interval(self):
+        """Sleep so consecutive requests are at least min_request_interval apart.
+
+        The Kitsune/SUMO API rate-limits clients that request faster than
+        roughly once per second. Only the remaining time since the previous
+        request is slept, so slow requests are not delayed unnecessarily.
+        """
+        if self.min_request_interval > 0 and self._last_request is not None:
+            wait = self.min_request_interval - (time.monotonic() - self._last_request)
+            if wait > 0:
+                time.sleep(wait)
+        self._last_request = time.monotonic()
+
     def fetch(self, url, params):
         """Return the textual content associated to the Response object"""
 
@@ -327,6 +354,8 @@ class KitsuneClient(HttpClient):
 
         retries = self.max_retries
         while retries >= 0:
+            # Throttle before each request to respect the API rate limit.
+            self._wait_for_min_interval()
             try:
                 response = super().fetch(url, payload=params)
                 return response.text
@@ -336,9 +365,6 @@ class KitsuneClient(HttpClient):
                     self.sleep_for_rate_limit()
                 else:
                     raise ex
-            finally:
-                # Avoids to do requests too fast
-                time.sleep(0.5)
 
         raise HttpClientError(cause="Max retries exceeded")
 
@@ -373,4 +399,8 @@ class KitsuneCommand(BackendCommand):
         group.add_argument('--sleep-time', dest='sleep_time',
                            default=DEFAULT_SLEEP_TIME, type=int,
                            help="sleeping time between API call retries")
+        group.add_argument('--min-request-interval', dest='min_request_interval',
+                           default=MIN_REQUEST_INTERVAL, type=float,
+                           help="minimum seconds between consecutive API requests "
+                                "(default: %s)" % MIN_REQUEST_INTERVAL)
         return parser

--- a/releases/unreleased/kitsune-rate-limit-interval.yml
+++ b/releases/unreleased/kitsune-rate-limit-interval.yml
@@ -1,0 +1,11 @@
+---
+title: 'Kitsune: throttle API requests to respect the rate limit'
+category: fixed
+author: Arron Atchison <aatchison@thunderbird.net>
+issue: null
+notes: >
+    The Kitsune backend now waits at least one second between consecutive
+    API requests. The support.mozilla.org API rate-limits clients that
+    request faster than roughly once per second, which could abort or stall
+    data collection. The interval is configurable through the new
+    `--min-request-interval` option (default: 1.0s).

--- a/tests/test_kitsune.py
+++ b/tests/test_kitsune.py
@@ -312,7 +312,12 @@ class TestKitsuneCommand(unittest.TestCase):
         self.assertTrue(parsed_args.ssl_verify)
         self.assertTrue(parsed_args.sleep_for_rate)
         self.assertEqual(parsed_args.max_retries, 10)
+        self.assertGreaterEqual(parsed_args.min_request_interval, 1.0)
         self.assertIsNone(parsed_args.blacklist_ids)
+
+        args = [KITSUNE_SERVER_URL, '--min-request-interval', '2.5']
+        parsed_args = parser.parse(*args)
+        self.assertEqual(parsed_args.min_request_interval, 2.5)
 
         args = [KITSUNE_SERVER_URL,
                 '--no-ssl-verify',
@@ -364,6 +369,34 @@ class TestKitsuneClient(unittest.TestCase):
         self.assertEqual(kitsune.sleep_for_rate, True)
         self.assertEqual(kitsune.sleep_time, 100)
         self.assertEqual(kitsune.max_retries, 10)
+
+    def test_default_min_request_interval(self):
+        """By default the client waits at least 1s between API calls.
+
+        The Kitsune/SUMO API rate-limits clients that issue requests faster
+        than roughly one per second, so the default spacing must be >= 1s.
+        """
+        kitsune = KitsuneClient(KITSUNE_SERVER_URL)
+
+        self.assertGreaterEqual(kitsune.min_request_interval, 1.0)
+
+    @httpretty.activate
+    def test_fetch_respects_min_request_interval(self):
+        """Consecutive requests are spaced by at least min_request_interval."""
+
+        HTTPServer.routes()
+        HTTPServer.requests_http = []
+
+        interval = 1.5
+        client = KitsuneClient(KITSUNE_SERVER_URL, min_request_interval=interval)
+
+        with unittest.mock.patch('time.sleep') as mock_sleep:
+            # Two pages -> two API requests -> one inter-request gap.
+            list(client.get_questions(from_date=str_to_datetime("1970-01-01")))
+
+        slept = [call.args[0] for call in mock_sleep.call_args_list if call.args]
+        self.assertTrue(slept, "client should sleep between requests")
+        self.assertGreaterEqual(max(slept), interval - 0.1)
 
     @httpretty.activate
     def test_get_questions(self):


### PR DESCRIPTION
## Who we are

We're [Thunderbird](https://www.thunderbird.net/) (MZLA). We run a GrimoireLab/Bitergia analytics instance at **https://bitergia.thunderbird.net** that uses the Kitsune backend to ingest support.mozilla.org (SUMO) data.

## Problem

The Kitsune/SUMO API rate-limits clients that issue requests faster than roughly **one per second**. The client only guarded against this with a fixed `time.sleep(0.5)` after each request (in `KitsuneClient.fetch`), which is below that threshold. Under sustained collection this gets throttled, which stalls/aborts ingestion.

## Change

- Replace the hardcoded `time.sleep(0.5)` with a configurable `min_request_interval` (**default `1.0`s**).
- Enforce it as an **elapsed-aware floor** between consecutive requests (`_wait_for_min_interval`): only the time *remaining* since the previous request is slept, so genuinely slow requests aren't delayed further.
- Expose it via a new `--min-request-interval` CLI option, threaded `Kitsune` → `KitsuneClient`.
- Bump backend `version` 2.1.0 → 2.2.0.

This keeps the existing 429 `--sleep-for-rate` retry behaviour unchanged; it just guarantees a sane minimum spacing between *all* requests.

## Tests

Added to `tests/test_kitsune.py`:

- `test_default_min_request_interval` — the client defaults to `>= 1s` spacing.
- `test_fetch_respects_min_request_interval` — consecutive requests are spaced by the configured interval.
- Extended `test_setup_cmd_parser` — `--min-request-interval` default and override parse correctly.

Full `test_kitsune` suite (18 tests) passes locally; `flake8` clean; changelog entry added under `releases/unreleased/`.

> Marked **draft**: we're validating it against our production ingestion first and will mark ready once confirmed.